### PR TITLE
Fix  `invoke` return, add `MaxSize` parameter

### DIFF
--- a/Function.h
+++ b/Function.h
@@ -111,9 +111,9 @@ private:
   using Manager = void (*)(Storage *, Storage *, Operation);
 
   template <typename F>
-  static inline void invoke(Storage *data, Args &&... args) {
+  static R invoke(Storage *data, Args &&... args) {
     F &f = *static_cast<F *>(reinterpret_cast<void *>(data));
-    f(std::forward<Args>(args)...);
+    return f(std::forward<Args>(args)...);
   }
 
   template <typename F>

--- a/Function.h
+++ b/Function.h
@@ -27,9 +27,9 @@ SOFTWARE.
 #include <functional>
 #include <memory>
 
-template <class> class Function;
+template <class, size_t MaxSize = 1024> class Function;
 
-template <class R, class... Args> class Function<R(Args...)> {
+template <class R, class... Args, size_t MaxSize> class Function<R(Args...), MaxSize> {
 public:
   Function() noexcept {}
 
@@ -106,24 +106,24 @@ public:
 private:
   enum class Operation { Clone, Destroy };
 
-  using Storage = typename std::aligned_storage<1024, 8>::type;
-  using Invoker = R (*)(Storage *, Args &&...);
-  using Manager = void (*)(Storage *, Storage *, Operation);
+  using Invoker = R (*)(void *, Args &&...);
+  using Manager = void (*)(void *, void *, Operation);
+  using Storage = typename std::aligned_storage<MaxSize - sizeof(Invoker) - sizeof(Manager), 8>::type;
 
   template <typename F>
-  static R invoke(Storage *data, Args &&... args) {
-    F &f = *static_cast<F *>(reinterpret_cast<void *>(data));
+  static R invoke(void *data, Args &&... args) {
+    F &f = *static_cast<F *>(data);
     return f(std::forward<Args>(args)...);
   }
 
   template <typename F>
-  static void manage(Storage *dest, Storage *src, Operation op) {
+  static void manage(void *dest, void *src, Operation op) {
     switch (op) {
     case Operation::Clone:
-      new (dest) F(*static_cast<F *>(reinterpret_cast<void *>(src)));
+      new (dest) F(*static_cast<F *>(src));
       break;
     case Operation::Destroy:
-      static_cast<F *>(reinterpret_cast<void *>(dest))->~F();
+      static_cast<F *>(dest)->~F();
       break;
     }
   }

--- a/example.cpp
+++ b/example.cpp
@@ -5,12 +5,13 @@ int main(int argc, char *argv[]) {
   int foo = 1;
   double bar = 3;
 
-  Function<int (std::ostream &)> f([=](std::ostream &os) {
+  Function<int (std::ostream &), 128> f([=](std::ostream &os) {
     os << "test " << foo << " " << bar << std::endl;
     return foo;
   });
 
   f(std::cout);
+  std::cout << "Size of Function: " << sizeof(f) << '\n';
 
   return 0;
 }

--- a/example.cpp
+++ b/example.cpp
@@ -5,8 +5,9 @@ int main(int argc, char *argv[]) {
   int foo = 1;
   double bar = 3;
 
-  Function<void(std::ostream &)> f([=](std::ostream &os) {
+  Function<int (std::ostream &)> f([=](std::ostream &os) {
     os << "test " << foo << " " << bar << std::endl;
+    return foo;
   });
 
   f(std::cout);


### PR DESCRIPTION
Hi Erik!

I've made a similar solution for `std::function` with fixed size storage some time ago, and I used the same way to implement it. Nice trick with swap in move ctor by the way, I've never seen it before.

I'd like to share a couple of commits. The first commit fixes an error for Functions with non-void return type. And another commit adds an optional `MaxSize` template parameter which controls the final size of Function.
