### PR TITLE
Fixed nullptr assignment, allow a reference to free function

### DIFF
--- a/Function.h
+++ b/Function.h
@@ -46,11 +46,12 @@ public:
   Function(Function &&other) { other.swap(*this); }
 
   template <class F> Function(F &&f) {
-    static_assert(alignof(F) <= alignof(Storage), "invalid alignment");
-    static_assert(sizeof(F) <= sizeof(Storage), "storage too small");
-    new (&data) F(std::forward<F>(f));
-    invoker = &invoke<F>;
-    manager = &manage<F>;
+    using f_type = typename std::decay<F>::type;
+    static_assert(alignof(f_type) <= alignof(Storage), "invalid alignment");
+    static_assert(sizeof(f_type) <= sizeof(Storage), "storage too small");
+    new (&data) f_type(std::forward<F>(f));
+    invoker = &invoke<f_type>;
+    manager = &manage<f_type>;
   }
 
   ~Function() {

--- a/Function.h
+++ b/Function.h
@@ -72,7 +72,7 @@ public:
 
   Function &operator=(std::nullptr_t) {
     if (manager) {
-      manager(data, nullptr, Operation::Destroy);
+      manager(&data, nullptr, Operation::Destroy);
       manager = nullptr;
       invoker = nullptr;
     }

--- a/example.cpp
+++ b/example.cpp
@@ -45,7 +45,11 @@ int main(int argc, char *argv[]) {
   f = cl;
   f(std::cout);
 
-  f(std::cout);
+  f = nullptr;
+  try { f(std::cout); }
+  catch (std::bad_function_call const&) { }
+  std::cout << "Assigned nullptr, function is " << (f? "not " : "") << "empty\n";
+
   std::cout << "Size of Function: " << sizeof(f) << '\n';
 
   return 0;

--- a/example.cpp
+++ b/example.cpp
@@ -1,6 +1,27 @@
 #include "Function.h"
 #include <iostream>
 
+int function(std::ostream& os)
+{
+  os << "Free function\n";
+  return 0;
+}
+
+struct Class
+{
+  int operator()(std::ostream& os)
+  {
+    os << "Class::operator()\n";
+    return 1;
+  }
+
+  int fun(std::ostream& os)
+  {
+    os << "Class::fun()\n";
+    return 2;
+  }
+};
+
 int main(int argc, char *argv[]) {
   int foo = 1;
   double bar = 3;
@@ -9,6 +30,20 @@ int main(int argc, char *argv[]) {
     os << "test " << foo << " " << bar << std::endl;
     return foo;
   });
+  f(std::cout);
+
+  f = &function;
+  f(std::cout);
+
+  f = function;
+  f(std::cout);
+
+  Class cl;
+  f = std::bind(&Class::fun, &cl, std::placeholders::_1);
+  f(std::cout);
+
+  f = cl;
+  f(std::cout);
 
   f(std::cout);
   std::cout << "Size of Function: " << sizeof(f) << '\n';


### PR DESCRIPTION
Hi Erik,

There is a small fix for `nullptr` assignment. And I also added `std::decay<F>` to deal with references to free functions in the template Function constructor.
